### PR TITLE
fix(settings): resolve GORM scan errors and update Stellar Mainnet RPC

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"gcw/entity"
 	"os"
-	"time"
+
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -50,9 +50,18 @@ func SetupDatabaseConnection() *gorm.DB {
 		var count int64
 		db.Model(&entity.SystemSetting{}).Count(&count)
 		if count == 0 {
-			proposalDeadline, _ := time.Parse("2006-01-02T15:04:05", "2026-05-24T23:59:59")
-			videoDeadline, _ := time.Parse("2006-01-02T15:04:05", "2026-06-06T23:59:59")
-			finalDeadline, _ := time.Parse("2006-01-02T15:04:05", "2026-06-20T23:59:59")
+			proposalDeadline := os.Getenv("HACKATHON_PROPOSAL_DEADLINE")
+			if proposalDeadline == "" {
+				proposalDeadline = "2026-05-24T23:59:59"
+			}
+			videoDeadline := os.Getenv("HACKATHON_VIDEO_DEADLINE")
+			if videoDeadline == "" {
+				videoDeadline = "2026-06-06T23:59:59"
+			}
+			finalDeadline := os.Getenv("HACKATHON_FINAL_DEADLINE")
+			if finalDeadline == "" {
+				finalDeadline = "2026-06-20T23:59:59"
+			}
 			
 			initialSettings := entity.SystemSetting{
 				ID:                            1,

--- a/dto/system_setting.go
+++ b/dto/system_setting.go
@@ -1,6 +1,6 @@
 package dto
 
-import "time"
+
 
 type UpdateSystemSettingDTO struct {
 	HackathonRegistrationDisabled bool       `json:"hackathon_registration_disabled"`
@@ -9,7 +9,7 @@ type UpdateSystemSettingDTO struct {
 	HackathonProposalDisabled     bool       `json:"hackathon_proposal_disabled"`
 	HackathonVideoDisabled        bool       `json:"hackathon_video_disabled"`
 	HackathonFinalDisabled        bool       `json:"hackathon_final_disabled"`
-	HackathonProposalDeadline     *time.Time `json:"hackathon_proposal_deadline"`
-	HackathonVideoDeadline        *time.Time `json:"hackathon_video_deadline"`
-	HackathonFinalDeadline        *time.Time `json:"hackathon_final_deadline"`
+	HackathonProposalDeadline     *string `json:"hackathon_proposal_deadline"`
+	HackathonVideoDeadline        *string `json:"hackathon_video_deadline"`
+	HackathonFinalDeadline        *string `json:"hackathon_final_deadline"`
 }

--- a/entity/system_setting.go
+++ b/entity/system_setting.go
@@ -1,6 +1,6 @@
 package entity
 
-import "time"
+
 
 type SystemSetting struct {
 	ID                            uint       `gorm:"primaryKey" json:"id"`
@@ -10,7 +10,7 @@ type SystemSetting struct {
 	HackathonProposalDisabled     bool       `gorm:"default:false" json:"hackathon_proposal_disabled"`
 	HackathonVideoDisabled        bool       `gorm:"default:false" json:"hackathon_video_disabled"`
 	HackathonFinalDisabled        bool       `gorm:"default:false" json:"hackathon_final_disabled"`
-	HackathonProposalDeadline     *time.Time `json:"hackathon_proposal_deadline"`
-	HackathonVideoDeadline        *time.Time `json:"hackathon_video_deadline"`
-	HackathonFinalDeadline        *time.Time `json:"hackathon_final_deadline"`
+	HackathonProposalDeadline     *string `json:"hackathon_proposal_deadline"`
+	HackathonVideoDeadline        *string `json:"hackathon_video_deadline"`
+	HackathonFinalDeadline        *string `json:"hackathon_final_deadline"`
 }

--- a/service/submission-service.go
+++ b/service/submission-service.go
@@ -47,8 +47,9 @@ func (s *submissionService) Create(join_code, stage string, submissionDTO dto.Re
 			if setting.HackathonProposalDisabled {
 				return entity.HackathonTeam{}, fmt.Errorf("pengumpulan proposal (Stage 1) telah ditutup oleh administrator")
 			}
-			if setting.HackathonProposalDeadline != nil {
-				if time.Now().After(*setting.HackathonProposalDeadline) {
+			if setting.HackathonProposalDeadline != nil && *setting.HackathonProposalDeadline != "" {
+				parsedTime, err := time.Parse("2006-01-02T15:04:05", *setting.HackathonProposalDeadline)
+				if err == nil && time.Now().After(parsedTime) {
 					return entity.HackathonTeam{}, fmt.Errorf("batas waktu (deadline) pengumpulan proposal telah berakhir")
 				}
 			}
@@ -58,8 +59,9 @@ func (s *submissionService) Create(join_code, stage string, submissionDTO dto.Re
 			if setting.HackathonVideoDisabled {
 				return entity.HackathonTeam{}, fmt.Errorf("pengumpulan video (Stage 2) telah ditutup oleh administrator")
 			}
-			if setting.HackathonVideoDeadline != nil {
-				if time.Now().After(*setting.HackathonVideoDeadline) {
+			if setting.HackathonVideoDeadline != nil && *setting.HackathonVideoDeadline != "" {
+				parsedTime, err := time.Parse("2006-01-02T15:04:05", *setting.HackathonVideoDeadline)
+				if err == nil && time.Now().After(parsedTime) {
 					return entity.HackathonTeam{}, fmt.Errorf("batas waktu (deadline) pengumpulan video telah berakhir")
 				}
 			}
@@ -69,8 +71,9 @@ func (s *submissionService) Create(join_code, stage string, submissionDTO dto.Re
 			if setting.HackathonFinalDisabled {
 				return entity.HackathonTeam{}, fmt.Errorf("pengumpulan presentasi final telah ditutup oleh administrator")
 			}
-			if setting.HackathonFinalDeadline != nil {
-				if time.Now().After(*setting.HackathonFinalDeadline) {
+			if setting.HackathonFinalDeadline != nil && *setting.HackathonFinalDeadline != "" {
+				parsedTime, err := time.Parse("2006-01-02T15:04:05", *setting.HackathonFinalDeadline)
+				if err == nil && time.Now().After(parsedTime) {
 					return entity.HackathonTeam{}, fmt.Errorf("batas waktu (deadline) pengumpulan presentasi final telah berakhir")
 				}
 			}

--- a/service/system-setting-service.go
+++ b/service/system-setting-service.go
@@ -15,16 +15,15 @@ func NewSystemSettingService(db *gorm.DB) *SystemSettingService {
 
 func (s *SystemSettingService) GetSettings() (entity.SystemSetting, error) {
 	var setting entity.SystemSetting
-	err := s.db.First(&setting, 1).Error
+	err := s.db.First(&setting).Error
 	return setting, err
 }
 
 func (s *SystemSettingService) UpdateSettings(newSettings entity.SystemSetting) (entity.SystemSetting, error) {
 	var setting entity.SystemSetting
-	err := s.db.First(&setting, 1).Error
+	err := s.db.First(&setting).Error
 	if err != nil {
 		// If settings don't exist yet, create the first record
-		newSettings.ID = 1
 		err = s.db.Create(&newSettings).Error
 		return newSettings, err
 	}


### PR DESCRIPTION
- Change deadline fields in SystemSetting entity and DTO from *time.Time to *string to prevent GORM unsupported scan errors.
- Update submission service to parse string deadlines back into time.Time for validation.
- Refactor system-setting service to query the first available record instead of hardcoding ID 1, fixing 500 Duplicate Key errors.
- Update database seed logic to fetch default deadlines from .env variables.
- Update STELLAR_RPC_URL to https://mainnet.sorobanrpc.com to fix NXDOMAIN simulation errors.