### PR TITLE
fix(audit): revert to using email for internal database audit logs

### DIFF
--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -196,10 +196,10 @@ func (m *auditMiddleware) generateDescription(method, path string, body interfac
 			targetResourceID = uint64(id)
 		}
 	}
-	// User identifier: use ID if available, otherwise "User"
+	// User identifier: use email if available, otherwise "User"
 	userLabel := "User"
-	if user != nil && user.ID != 0 {
-		userLabel = fmt.Sprintf("User %d", user.ID)
+	if user != nil && user.Email != "" {
+		userLabel = user.Email
 	}
 
 	// Target name/email from context if set by handler


### PR DESCRIPTION
- Revert  logic in  to use the user's email instead of ID.
- This ensures human-readable activity logs in the admin panel and internal PostgreSQL database.
- Blockchain privacy is maintained as  automatically redacts the email to User ID before generating the cryptographic hash for the Stellar network.